### PR TITLE
Properly handle month/year at turn of the year

### DIFF
--- a/lib/controllr.rb
+++ b/lib/controllr.rb
@@ -15,16 +15,16 @@ class Controllr
   end
 
   # @param month [Fixnum] the month as a number (starting at 1 for January), see `Date#month`.
-  def performance(month)
-    data = fetch("/api/monthly_salaries/spreadsheet_data.json?month=#{month}")
+  def performance(month, year)
+    data = fetch("/api/monthly_salaries/spreadsheet_data.json?month=#{month}&year=#{year}")
     data_totals = data['totals']
     performance = data_totals['internal_hours_billable'].to_f / data_totals['internal_hours_worked'].to_f
 
     performance.round(2)
   end
 
-  def hours_worked(month)
-    data = fetch("/api/monthly_salaries/spreadsheet_data.json?month=#{month}")
+  def hours_worked(month, year)
+    data = fetch("/api/monthly_salaries/spreadsheet_data.json?month=#{month}&year=#{year}")
     data_totals = data['totals']
     data_totals['internal_hours_worked'].to_i
   end

--- a/lib/data_fetchers/controllr_fetcher.rb
+++ b/lib/data_fetchers/controllr_fetcher.rb
@@ -28,14 +28,14 @@ class ControllrFetcher
 
   def performance
     performance_month = Date.today.prev_month.prev_month
-    last_performance = controllr.performance(performance_month.prev_month.month)
-    current_performance = controllr.performance(performance_month.month)
+    last_performance = controllr.performance(performance_month.prev_month.month, performance_month.year)
+    current_performance = controllr.performance(performance_month.month, performance_month.year)
 
     DataStore.set('salary-performance', { current: current_performance, last: last_performance })
   end
 
   def working_hours
-    hours_worked = controllr.hours_worked(Date.today.month)
+    hours_worked = controllr.hours_worked(Date.today.month, Date.today.year)
     DataStore.set('hours-worked', { current: hours_worked })
   end
 

--- a/lib/data_fetchers/controllr_fetcher.rb
+++ b/lib/data_fetchers/controllr_fetcher.rb
@@ -40,7 +40,10 @@ class ControllrFetcher
   end
 
   def salaries
-    points = YAML.load_file('config/salaries.yml')[Date.today.year].map do |key, value|
+    to_month = Date.today.prev_month.prev_month
+    years_salaries = YAML.load_file('config/salaries.yml')[to_month.year]
+    years_salaries = (1..to_month.month).map { |month| [month, years_salaries[month]] }.to_h
+    points = years_salaries.map do |key, value|
       {
         x: key,
         y: value[0],


### PR DESCRIPTION
1. we need to pass the month and the year as well, as the year defaults
   to the current year, which on the verge to a new year is not what
   we expect.
2. Calculate back from current month/year for salaries
