### PR TITLE
Use non-root gitlab api user and narrower scope

### DIFF
--- a/lib/gitlab_client.rb
+++ b/lib/gitlab_client.rb
@@ -16,8 +16,6 @@ class GitlabClient
   # some repositories exist on github as well.
   REPOSITORY_BLACKLIST = (ENV['GITLAB_REPO_BLACKLIST'] || '').split(',')
 
-  ORGANIZATION_NAME = ENV['GITLAB_ORGANIZATION_NAME']
-
   def initialize
     Gitlab.endpoint = ENV['GITLAB_URL']
     Gitlab.private_token = ENV['GITLAB_PRIVATE_TOKEN']
@@ -26,11 +24,10 @@ class GitlabClient
   def projects
     @projects ||=
       begin
-        projects = paginate(:projects, options: { scope: :all })
+        projects = paginate(:projects, options: { scope: :owned })
 
         # exclude projects without proper repositories
         projects
-          .select { |project| project.namespace.name == ORGANIZATION_NAME }
           .select { |project| project.default_branch }
           .reject { |project| REPOSITORY_BLACKLIST.include?(project.path_with_namespace) }
       end


### PR DESCRIPTION
We can now use the GITLAB_PRIVATE_TOKEN of the gitlab-api
user instead of the root user.
